### PR TITLE
Fix issue with Content-Length header being calculated incorrectly

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -62,7 +62,7 @@ module.exports = function(api_key) {
         'Accept': 'application/vnd.blockscore+json;version=4',
         'User-Agent': 'blockscore-node/4.0.0 (https://github.com/BlockScore/blockscore-node)',
         'Content-Type': 'application/json',
-        'Content-Length': request_data.length
+        'Content-Length': Buffer.byteLength(request_data)
       },
       agent: false
     };


### PR DESCRIPTION
As mentioned in #25, the `Content-Length` header is not calculated correctly for strings containing certain unicode characters. Here's a summary of the issue:

> … the issue here is that [the blockscore-node package is relying on `String.length` to determine the `Content-Length` header](https://github.com/BlockScore/blockscore-node/blob/5fa536a3f0794de3f7a4f00ef6ccba714f03f5d3/lib/main.js?ts=2#L65) but the header needs to be the **byte length**, not string length, e.g. 'Zürich' is 7 bytes, not 6. This package should use `Buffer.byteLength()` instead of `String.length` to determine the content length header.
> 
> For example, this request fails: (note `Content-Length: 345`)
> 
> ```bash
> curl -X POST https://api.blockscore.com/candidates \
>   -u "$BLOCKSCORE_API_KEY:" \
>   -H 'Accept: application/vnd.blockscore+json;version=4' \
>   -H 'Content-Type: application/json' \
>   -H 'Content-Length: 345' \
>   -d '{"birth_day":"xx","birth_month":"xx","birth_year":"xxxx","document_value":"Fxxxxxxx","document_type":"passport","name_first":"First","name_middle":"","name_last":"Last","address_street1":"Weststrasse xxx","address_city":"Zürich","address_subdivision":"ZH","address_postal_code":"xxxx","address_country_code":"CH","phone_number":"00xxxxxxxxxxxx"}'
> ```
> 
> with the response,
> 
> ```json
> {
>   "error": {
>     "type": "invalid_request_error",
>     "message": "Poorly formed JSON request body."
>   }
> }
> ```
> 
> while this request succeeds: (note `Content-Length: 346`)
> 
> ```bash
> curl -X POST https://api.blockscore.com/candidates \
>   -u "$BLOCKSCORE_API_KEY:" \
>   -H 'Accept: application/vnd.blockscore+json;version=4' \
>   -H 'Content-Type: application/json' \
>   -H 'Content-Length: 346' \
>   -d '{"birth_day":"xx","birth_month":"xx","birth_year":"xxxx","document_value":"Fxxxxxxx","document_type":"passport","name_first":"First","name_middle":"","name_last":"Last","address_street1":"Weststrasse xxx","address_city":"Zürich","address_subdivision":"ZH","address_postal_code":"xxxx","address_country_code":"CH","phone_number":"00xxxxxxxxxxxx"}'
> ```

Closes #25.